### PR TITLE
Update lodash to version 4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ var _ = require('lodash');
 var arr = [{a : 3}, {a: 4}];
 var ctx = {b : 5};
 
-var transformed =  _.map(arr, function(obj) {return obj.a + this.b}, ctx);
+var transformed =  _.map(arr, (function(obj) {return obj.a + this.b}).bind(ctx));
 
 console.log(transformed.join(', '));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "lodash": "3.10.1"
+    "lodash": "^4.0.0"
   }
 }


### PR DESCRIPTION
This pull request was created using the JSFIX program analysis (https://jsfix.live) by Coana.tech (https://coana.tech)

It bumps lodash to version 4.0.0

JSFIX has adapted your code to all breaking changes introduced in lodash version 4.0.0

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request<details>
<summary>Click to show list of patched breaking changes</summary>
* Removed thisArg params from most methods because they were largely unused, complicated implementations, & can be tackled with _.bind, Function#bind, or arrow functions

  - [index.js#L6](https://github.com/jsfix-updater/lodash_client/mono/blob/c667e5c967d6d44e77a523c45fab120e35fa4533/index.js#L6)

</details>
